### PR TITLE
Separate ports for helios and services in the api-gateway

### DIFF
--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -13,9 +13,12 @@ server {
     proxy_pass $helios/heartbeat;
   }
 
-  # backwards compatibility; remove when VCL changes to point to 8200
   location /helios/token {
-    proxy_pass http://localhost:8200/helios/token;
+    set_by_lua $helios '
+      local util = require("util")
+      return util.strip_trailing_slash(require("config").HELIOS_URL)
+    ';
+    proxy_pass $helios/token;
   }
 
   location / {
@@ -43,22 +46,4 @@ server {
     proxy_pass $service_lb_url;
   }
 
-}
-
-server {
-  listen 8200 default_server;
-  server_name "" [::]:8200;
-  resolver 127.0.0.1:8600;
-
-  access_log /var/log/nginx/api-gateway.access.log log_format_with_perf;
-
-  location / {
-    set_by_lua $helios '
-      local util = require("util")
-      return util.strip_trailing_slash(require("config").HELIOS_URL)
-    ';
-
-    rewrite ^/healthcheck$ /heartbeat break;
-    proxy_pass $helios;
-  }
 }

--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -10,20 +10,11 @@ server {
       local util = require("util")
       return util.strip_trailing_slash(require("config").HELIOS_URL)
     ';
-
     proxy_pass $helios/heartbeat;
   }
 
-  location ~ /helios/(.*) {
-    set_by_lua $helios '
-      local util = require("util")
-      return util.strip_trailing_slash(require("config").HELIOS_URL)
-    ';
-
-    proxy_pass $helios/$1;
-  }
-
-  location ~ ^/service/(.*) {
+  location / {
+    rewrite ^/service/(.*)$ /$1 break;
     proxy_pass_request_headers off;
     set $service_path $1;
     content_by_lua '
@@ -33,18 +24,36 @@ server {
 
       local headers = ngx.req.get_headers(20)
       local user_id = nginx.authenticate(app, headers["Cookie"])
-      return nginx.service_proxy(ngx, ngx.var.service_path, user_id)
+      return nginx.service_proxy(ngx, user_id)
       ';
   }
 
-  location ~ ^/sub/service/(.*) {
-    internal;
+  location  @service {
     set_by_lua $service_lb_url '
       local util = require("util")
+
       return util.strip_trailing_slash(require("config").SERVICE_LB_URL)
     ';
 
-    proxy_pass $service_lb_url/$1;
+    proxy_pass $service_lb_url;
   }
 
+}
+
+server {
+  listen 8200 default_server;
+  server_name "" [::]:8200;
+  resolver 127.0.0.1:8600;
+
+  access_log /var/log/nginx/api-gateway.access.log log_format_with_perf;
+
+  location / {
+    set_by_lua $helios '
+      local util = require("util")
+      return util.strip_trailing_slash(require("config").HELIOS_URL)
+    ';
+
+    rewrite ^/healthcheck$ /heartbeat break;
+    proxy_pass $helios;
+  }
 }

--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -13,6 +13,11 @@ server {
     proxy_pass $helios/heartbeat;
   }
 
+  # backwards compatibility; remove when VCL changes to point to 8200
+  location /helios/token {
+    proxy_pass http://localhost:8200/helios/token;
+  }
+
   location / {
     rewrite ^/service/(.*)$ /$1 break;
     proxy_pass_request_headers off;

--- a/spec/nginx_spec.lua
+++ b/spec/nginx_spec.lua
@@ -29,10 +29,9 @@ describe("nginx module tests", function()
     it("will set the user id header when supplied", function()
       local nginx = require "nginx"
       local user_id = 1234;
-      local ret = nginx.service_proxy(ngx, "/user-preference", user_id)
+      local ret = nginx.service_proxy(ngx, user_id)
 
-      assert.stub(ngx.exec).was.called_with(
-      string.format("%s%s", nginx.SERVICE_PROXY_PATH, "/user-preference"))
+      assert.stub(ngx.exec).was.called_with("@service")
 
       assert.stub(ngx.req.set_header).was_called_with(auth.USER_ID_HEADER, user_id)
       assert.stub(ngx.req.set_header).was_called_with("Cookie", "")
@@ -41,10 +40,9 @@ describe("nginx module tests", function()
     it("will clear the user id header when the user id is not supplied", function()
       local nginx = require "nginx"
       local user_id = nil;
-      local ret = nginx.service_proxy(ngx, "/user-preference", user_id)
+      local ret = nginx.service_proxy(ngx, user_id)
 
-      assert.stub(ngx.exec).was.called_with(
-      string.format("%s%s", nginx.SERVICE_PROXY_PATH, "/user-preference"))
+      assert.stub(ngx.exec).was.called_with("@service")
 
       assert.stub(ngx.req.set_header).was_called_with(auth.USER_ID_HEADER, "")
       assert.stub(ngx.req.set_header).was_called_with("Cookie", "")

--- a/src/nginx.lua
+++ b/src/nginx.lua
@@ -51,7 +51,7 @@ function nginx.authenticate(app, cookie_string)
   return nil
 end
 
-function nginx.service_proxy(ngx, service_path, user_id)
+function nginx.service_proxy(ngx, user_id)
   -- the X-Wikia-UserId header should either be set by a valid
   -- user id or cleared
   if user_id then
@@ -63,8 +63,7 @@ function nginx.service_proxy(ngx, service_path, user_id)
   -- clear the cookie; it should not be sent to the backend
   ngx.req.set_header("Cookie", "")
 
-  return ngx.exec(string.format("%s/%s", SERVICE_PROXY_PATH,
-    util.strip_leading_slash(service_path)))
+  return ngx.exec("@service")
 end
 
 


### PR DESCRIPTION
Based on @pchojnacki suggestion, I separated the services and helios `server` blocks onto separate ports. This has the following effects:

 * Removes the need for regex replacement of `/service` in the VCL
 * Removes the need to pass the URI to the sub request within nginx when proxying to services.
 * Simplifies the pass through auth handling
 * Fixes the passing of query parameters (nginx was stripping them under the previous config)
 * Moves helios to port 8200

This should be 100% backwards compatible with the existing configuration.

/cc @pchojnacki @frankfarmer 