### PR TITLE
Change session_token to access_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ busted spec
 	 for more details regarding the session token handling.
 
 
-If the `session_token` cookie exists and is not empty then an attempt will be
+If the `access_token` cookie exists and is not empty then an attempt will be
 made to authenticate the token against helios and retrieve the user id of the
 user to whom the token belongs. If a user id is returned from helios then that
 user id will be provided in the `X-Wikia-UserId` header sent to the service.
 
-If the `session_token` cookie is absent, expired, or invalid then no
+If the `access_token` cookie is absent, expired, or invalid then no
 `X-Wikia-UserId` will be sent to the service.
 
 ## Developing with Nginx Locally
@@ -46,7 +46,7 @@ To start:
 You can test the basic functionality with:
 
 ```
-curl -H “Cookie: session_token=<token>” http://127.0.0.1:8089/service/...
+curl -H “Cookie: access_token=<token>” http://127.0.0.1:8089/service/...
 ```
 
 ```

--- a/spec/auth_spec.lua
+++ b/spec/auth_spec.lua
@@ -4,7 +4,7 @@ local helios = require "mocks.gateway.helios"
 describe("authentication tests", function()
   describe("authenticate_and_return_user_id", function()
     before_each(function()
-      session_token = "abcdef"
+      access_token = "abcdef"
       expected_user_id = 1234
     end)
 
@@ -14,7 +14,7 @@ describe("authentication tests", function()
 
       local auth_client = auth:new(helios)
 
-      local user_id = auth_client:authenticate_and_return_user_id(session_token)
+      local user_id = auth_client:authenticate_and_return_user_id(access_token)
       assert.are.equal(expected_user_id, user_id)
       assert.spy(helios.validate_token).was.called()
     end)
@@ -25,7 +25,7 @@ describe("authentication tests", function()
 
       local auth_client = auth:new(helios)
 
-      local user_id = auth_client:authenticate_and_return_user_id(session_token)
+      local user_id = auth_client:authenticate_and_return_user_id(access_token)
       assert.are.equal(nil, user_id)
       assert.spy(helios.validate_token).was.called()
     end)
@@ -36,7 +36,7 @@ describe("authentication tests", function()
 
       local auth_client = auth:new(helios)
 
-      local user_id = auth_client:authenticate_and_return_user_id(session_token)
+      local user_id = auth_client:authenticate_and_return_user_id(access_token)
       assert.are.equal(nil, user_id)
       assert.spy(helios.validate_token).was.called()
     end)
@@ -55,7 +55,7 @@ describe("authentication tests", function()
 			
 		end)
 
-		it("returns nil when given a cookie missing session_token", function()
+		it("returns nil when given a cookie missing access_token", function()
 			local auth_client = auth:new({})
 			assert.are.equal(nil, auth_client:authenticate("foo=bar"))
 		end)
@@ -66,7 +66,7 @@ describe("authentication tests", function()
 
       local auth_client = auth:new(helios)
 
-      local user_id = auth_client:authenticate("session_token=abcdefg")
+      local user_id = auth_client:authenticate("access_token=abcdefg")
       assert.are.equal(expected_user_id, user_id)
       assert.spy(helios.validate_token).was.called()
 		end)

--- a/spec/cookie_spec.lua
+++ b/spec/cookie_spec.lua
@@ -1,8 +1,8 @@
 local cookie = require "cookie"
 describe("cookie parsing", function()
   it("tests that we can parse a basic cookie", function()
-    local cookie_string = "session_token=1234"
-    local parsed_cookie = {session_token = "1234"}
+    local cookie_string = "access_token=1234"
+    local parsed_cookie = {access_token = "1234"}
     assert.are.same(parsed_cookie, cookie.parse(cookie_string))
   end)
 
@@ -13,8 +13,8 @@ describe("cookie parsing", function()
 
   describe("compound cookie parsing", function()
     before_each(function()
-      cookie_string = "session_token=1234; other_value=abced\""
-      parsed_cookie = {session_token = "1234",other_value = "abced\""}
+      cookie_string = "access_token=1234; other_value=abced\""
+      parsed_cookie = {access_token = "1234",other_value = "abced\""}
     end)
 
     it("tests that we can parse a compound cookie", function()
@@ -23,7 +23,7 @@ describe("cookie parsing", function()
 
     it("test that we find the cookie we expect", function()
       local cookie_map = cookie.parse(cookie_string)
-      assert.are.same(parsed_cookie.session_token, cookie_map.session_token)
+      assert.are.same(parsed_cookie.access_token, cookie_map.access_token)
     end)
   end)
 end)

--- a/src/auth.lua
+++ b/src/auth.lua
@@ -17,11 +17,11 @@ end
 
 -- 
 -- Authenticate a user based on the token.
--- @param session_token
+-- @param access_token
 -- @return user id
 --
-function auth:authenticate_and_return_user_id(session_token)
-  local user_id = self.helios:validate_token(session_token)
+function auth:authenticate_and_return_user_id(access_token)
+  local user_id = self.helios:validate_token(access_token)
   if user_id then
     return user_id
   end
@@ -35,8 +35,8 @@ function auth:authenticate(cookie_string)
   end
 
   local cookie_map = cookie.parse(cookie_string)
-  if cookie_map.session_token then
-    local user_id = self:authenticate_and_return_user_id(cookie_map.session_token)
+  if cookie_map.access_token then
+    local user_id = self:authenticate_and_return_user_id(cookie_map.access_token)
     if user_id then
       return user_id
     end

--- a/src/gateway/helios.lua
+++ b/src/gateway/helios.lua
@@ -21,8 +21,8 @@ end
 -- @param session token
 -- @return user id | nil
 --
-function helios:validate_token(session_token)
-  local url = self:request_url(session_token)
+function helios:validate_token(access_token)
+  local url = self:request_url(access_token)
   local res, err = self.net:get(url)
 
   if res and res.body then
@@ -57,8 +57,8 @@ function helios:healthcheck()
 end
 
 
-function helios:request_url(session_token)
-  return string.format("%s/info?code=%s", self.helios_url, session_token)
+function helios:request_url(access_token)
+  return string.format("%s/info?code=%s", self.helios_url, access_token)
 end
 
 function helios:healthcheck_url()

--- a/src/mocks/gateway/helios.lua
+++ b/src/mocks/gateway/helios.lua
@@ -10,7 +10,7 @@ function helios:new(response_map)
   return setmetatable(out, { __index = self })
 end
 
-function helios:validate_token(session_token)
+function helios:validate_token(access_token)
   return self.response_map
 end
 


### PR DESCRIPTION
Change `session_token` to `access_token` so we are consistent with the other services.

/cc @ArturKlajnerok @nmonterroso 