### PR TITLE
SERVICES-324 Add /helios/register URI & rate limit

### DIFF
--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -18,5 +18,8 @@ http {
   access_log /var/log/nginx/access.log log_format_with_perf;
   error_log /var/log/nginx/error.log;
 
+  limit_req_zone $http_fastly_client_ip zone=registration:100m rate=12r/m;
+
+
   include '../production/api-gateway.conf';
 }

--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -22,6 +22,16 @@ server {
     proxy_pass $helios/token;
   }
 
+  location /helios/register {
+    limit_req zone=registration burst=2 nodelay;
+
+    set_by_lua $helios '
+      local util = require("util")
+      return util.strip_trailing_slash(require("config").HELIOS_URL)
+    ';
+    proxy_pass $helios/register;
+  }
+
   location / {
     rewrite ^/service/(.*)$ /$1 break;
     proxy_pass_request_headers off;


### PR DESCRIPTION
Add a `/helios/register` URI & rate limit it. The nginx documentation is [here](http://nginx.org/en/docs/http/ngx_http_limit_req_module.html).

https://wikia-inc.atlassian.net/browse/SERVICES-31

The corresponding chef-repo pull request is https://github.com/Wikia/chef-repo/pull/5277 for the `http` level directive `limit_req_zone`.

/cc @Wikia/services-team 