### PR TITLE
Add the resolver back into the nginx config

### DIFF
--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -1,6 +1,7 @@
 server {
   listen 8100 default_server;
   server_name "" [::]:8100;
+  resolver 127.0.0.1:8600;
 
   access_log /var/log/nginx/api-gateway.access.log log_format_with_perf;
   error_log /var/log/nginx/api-gateway.error.log;


### PR DESCRIPTION
Add the resolver back into the nginx. It's required for internal lua DNS resolution. This is specifically for the [request that happens here](https://github.com/Wikia/api-gateway/blob/master/src/gateway/helios.lua#L26) to helios using the `HELIOS_URL` from the config.

https://wikia-inc.atlassian.net/browse/SERVICES-457

/cc @Wikia/services-team