### PR TITLE
Fixes nginx errors and re-adds CORS support

### DIFF
--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -30,7 +30,7 @@ server {
       local nginx = require("nginx")
       local app = nginx.init(config)
 
-      local headers = ngx.req.get_headers(20)
+      local headers = ngx.req.get_headers(100)
       local user_id = nginx.authenticate(app, headers["Cookie"])
       return nginx.service_proxy(ngx, user_id)
       ';

--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -2,6 +2,7 @@ server {
   listen 8100 default_server;
   server_name "" [::]:8100;
   resolver 127.0.0.1:8600;
+  header_filter_by_lua_file "$api_gateway_root/src/nginx/scripts/add_cors_headers.lua";
 
   access_log /var/log/nginx/api-gateway.access.log log_format_with_perf;
   error_log /var/log/nginx/api-gateway.error.log;

--- a/src/cors.lua
+++ b/src/cors.lua
@@ -33,7 +33,7 @@ function cors.origin_matches_whitelist(origin_value)
 end
 
 function cors.get_origin_that_matches_whitelist(ngx)
-  local req_headers = ngx.req.get_headers(20)
+  local req_headers = ngx.req.get_headers(100)
   local origin = req_headers[cors.origin_header]
 
   if cors.origin_matches_whitelist(origin) then
@@ -46,7 +46,7 @@ end
 function cors.set_whitelisted_allow_origin_header(ngx, override_existing)
   -- check if already set then don't override
   if ngx.header[cors.allow_origin_header] == nil or override_existing then
-    local req_headers = ngx.req.get_headers(20)
+    local req_headers = ngx.req.get_headers(100)
     local origin = req_headers[cors.origin_header]
 
     if cors.origin_matches_whitelist(origin) then

--- a/src/cors.lua
+++ b/src/cors.lua
@@ -5,9 +5,18 @@ local cors = {
     "^.*%.wikia%-dev%.com$",
     "^wikia%-dev%.com$",
   },
-  allow_origin_header = 'Access-Control-Allow-Origin',
+
   origin_header = "Origin",
   vary_header = "Vary",
+  allow_origin_header = 'Access-Control-Allow-Origin',
+  allow_headers_header = "Access-Control-Allow-Headers",
+  allow_methods_header = "Access-Control-Allow-Methods",
+  allow_credentials_header = "Access-Control-Allow-Credentials",
+
+  allow_headers_default_value = "*",
+  allow_methods_default_value = "*",
+  allow_credentials_default_value = "true",
+
 }
 
 function cors.origin_matches_whitelist(origin_value)
@@ -23,8 +32,18 @@ function cors.origin_matches_whitelist(origin_value)
   return false
 end
 
+function cors.get_origin_that_matches_whitelist(ngx)
+  local req_headers = ngx.req.get_headers(20)
+  local origin = req_headers[cors.origin_header]
 
-function cors.set_whitelisted_allow_origin_header(ngx, override_existing)  
+  if cors.origin_matches_whitelist(origin) then
+    return origin
+  else
+    return nil
+  end
+end
+
+function cors.set_whitelisted_allow_origin_header(ngx, override_existing)
   -- check if already set then don't override
   if ngx.header[cors.allow_origin_header] == nil or override_existing then
     local req_headers = ngx.req.get_headers(20)
@@ -33,7 +52,23 @@ function cors.set_whitelisted_allow_origin_header(ngx, override_existing)
     if cors.origin_matches_whitelist(origin) then
       ngx.header[cors.allow_origin_header] = origin
     end
-  end  
+  end
+end
+
+function cors.set_whitelisted_control_headers(ngx)
+  local origin = cors.get_origin_that_matches_whitelist(ngx)
+  if origin ~= nil then
+    ngx.header[cors.allow_origin_header] = origin
+    ngx.header[cors.allow_headers_header] = cors.allow_headers_default_value
+    ngx.header[cors.allow_methods_header] = cors.allow_methods_default_value
+    ngx.header[cors.allow_credentials_header] = cors.allow_credentials_default_value
+  else
+    -- clean headers if origin doesn't match whitelist so that services will not be able to override this setting
+    ngx.header[cors.allow_origin_header] = nil
+    ngx.header[cors.allow_headers_header] = nil
+    ngx.header[cors.allow_methods_header] = nil
+    ngx.header[cors.allow_credentials_header] = nil
+  end
 end
 
 function cors.add_origin_to_vary_header(ngx)

--- a/src/nginx/net.lua
+++ b/src/nginx/net.lua
@@ -14,7 +14,7 @@ end
 
 function net:request(url, request_method, request_headers, body)
   if not request_headers then
-    request_headers = ngx.req.get_headers(20)
+    request_headers = ngx.req.get_headers(100)
   end
 
   local httpc = http.new()

--- a/src/nginx/scripts/add_cors_headers.lua
+++ b/src/nginx/scripts/add_cors_headers.lua
@@ -2,5 +2,4 @@ local cors = require("cors")
 
 cors.add_origin_to_vary_header(ngx)
 
--- set or override allow header 
-cors.set_whitelisted_allow_origin_header(ngx, true)
+cors.set_whitelisted_control_headers(ngx)

--- a/templates/conf/upstreams.conf
+++ b/templates/conf/upstreams.conf
@@ -5,10 +5,13 @@
 {{ if $service.Name }}{{if $tag}}
 {{ with $serviceQuery := printf "%s.%s" $tag $service.Name }}
 {{ if service $serviceQuery }}
+# query: {{$serviceQuery}}
+{{ with $queryResult := service $serviceQuery }}{{ if $queryResult }}
 upstream {{template "escape" $serviceQuery}} {
     {{range service $serviceQuery}}
         server {{.Address}}:{{.Port}};{{end}}
 }
+{{end}}{{end}}
 {{end}}{{end}}{{end}}{{end}}{{end}}{{end}}
 
 ### Upstream services configured from Consul K/V
@@ -18,8 +21,10 @@ upstream {{template "escape" $serviceQuery}} {
 {{/* serviceQuery needs to be sanitized as much as possible because otherwise it has the possibility of breaking consul */}}
 {{ with $serviceQuery := regexReplaceAll "[^a-zA-Z0-9@:._-]" "_" $item.Value }}
 # query: {{$serviceQuery}}
-upstream {{template "escape" $item.Key }}_{{template "escape" $serviceQuery}} {
-    {{range service $serviceQuery}}
+{{ with $queryResult := service $serviceQuery }}{{ if $queryResult }}
+upstream {{ template "escape" $item.Key }}_{{ template "escape" $serviceQuery }} {
+    {{ range $queryResult }}
         server {{.Address}}:{{.Port}};{{end}}
 }
+{{end}}{{end}}
 {{end}}{{end}}{{end}}{{end}}{{end}}


### PR DESCRIPTION
This change fixes potential errors caused by malformed upstreams.conf

Also Most of the CORS functionality was implemented previously but the filter wasn't enabled so it wasn't working.

Here I reintroduce CORS support with additional headers and setting making api-gateway the authoritative entity WRT to CORS headers. 

As API-Gateway *will* override all existing cors headers set by services. In an effort to standardize the CORS policies across services.

/cc: @kvas-damian @Wikia/services-team @jimmordino @ArturKlajnerok 