### PR TITLE
Add support for auth via X-Wikia-AccessToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ the following:
 busted spec
 ```
 
+## Local Integration Testing
+
+The integration testing local to this repository also uses busted. To run the
+integration tests do the following:
+
+```
+busted spec_integration
+```
+
+The integration tests require the following environment variables:
+
+ * `USERNAME`: the user name used to request a token from helios
+ * `PASSWORD`: the password used to request a token from helios
+ * `LOGIN_URL`: the login URL for helios
+ * `SERVICE_URL`: the service URL to attempt `GET` once a token has been
+	 aquired. This URL should require a token for the tests to work as expected.
+
 ## Resources
 
  * `/healthcheck`: Returns 200 status code on success. Checks to see that the

--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -31,7 +31,7 @@ server {
       local app = nginx.init(config)
 
       local headers = ngx.req.get_headers(100)
-      local user_id = nginx.authenticate(app, headers["Cookie"])
+      local user_id = nginx.authenticate(app, headers)
       return nginx.service_proxy(ngx, user_id)
       ';
   }

--- a/spec/auth_spec.lua
+++ b/spec/auth_spec.lua
@@ -39,18 +39,18 @@ describe("authentication tests", function()
 
 		it("returns nil when given a nil cookie", function()
 			local auth_client = auth:new({})
-			assert.are.equal(nil, auth_client:authenticate(nil))
+			assert.are.equal(nil, auth_client:authenticate_by_cookie(nil))
 		end)
 
 		it("returns nil when given an empty cookie", function()
 			local auth_client = auth:new({})
-			assert.are.equal(nil, auth_client:authenticate(""))
+			assert.are.equal(nil, auth_client:authenticate_by_cookie(""))
 
 		end)
 
 		it("returns nil when given a cookie missing access_token", function()
 			local auth_client = auth:new({})
-			assert.are.equal(nil, auth_client:authenticate("foo=bar"))
+			assert.are.equal(nil, auth_client:authenticate_by_cookie("foo=bar"))
 		end)
 
 		it("returns the user id when given a cookie with a valid access token", function()
@@ -58,7 +58,7 @@ describe("authentication tests", function()
 
       local auth_client = auth:new(helios)
 
-      local user_id = auth_client:authenticate("access_token=abcdefg")
+      local user_id = auth_client:authenticate_by_cookie("access_token=abcdefg")
       assert.are.equal(expected_user_id, user_id)
 		end)
 

--- a/spec/nginx_spec.lua
+++ b/spec/nginx_spec.lua
@@ -50,24 +50,45 @@ describe("nginx module tests", function()
 
   end)
 
-  describe("authenticate tests", function()
+  describe("authenticate using cookie tests", function()
     it("returns nil when the cookie_string is nil", function()
       local nginx = require "nginx"
-      assert.are.equal(nil, nginx.authenticate({}, nil))
-      assert.are.equal(nil, nginx.authenticate({}, ""))
+      assert.are.equal(nil, nginx.authenticate({}, { ["Cookie"] = nil }))
+      assert.are.equal(nil, nginx.authenticate({}, { ["Cookie"] = "" }))
     end)
 
     it("returns nil when authenticate returns nil", function()
       local auth = auth_mock:new(nil)
       local nginx = require "nginx"
-      assert.are.equal(nil, nginx.authenticate({ auth = auth }, "foo=abcd"))
+      assert.are.equal(nil, nginx.authenticate({ auth = auth }, { ["Cookie"] = "foo=abcd" }))
     end)
 
     it("returns the user id provided by authenticate", function()
       local user_id = 12345;
       local auth = auth_mock:new(user_id)
       local nginx = require "nginx"
-      assert.are.equal(user_id, nginx.authenticate({ auth = auth }, "foo=abcd"))
+      assert.are.equal(user_id, nginx.authenticate({ auth = auth }, { ["Cookie"] = "foo=abcd" }))
+    end)
+  end)
+
+  describe("authenticate using access token header tests", function()
+    it("returns nil when the cookie_string is nil", function()
+      local nginx = require "nginx"
+      assert.are.equal(nil, nginx.authenticate({}, { [auth.ACCESS_TOKEN_HEADER] = nil }))
+      assert.are.equal(nil, nginx.authenticate({}, { [auth.ACCESS_TOKEN_HEADER] = "" }))
+    end)
+
+    it("returns nil when authenticate returns nil", function()
+      local auth_mock = auth_mock:new(nil)
+      local nginx = require "nginx"
+      assert.are.equal(nil, nginx.authenticate({ auth = auth_mock }, { [auth.ACCESS_TOKEN_HEADER] = "abcd" }))
+    end)
+
+    it("returns the user id provided by authenticate", function()
+      local user_id = 12345;
+      local auth_mock = auth_mock:new(user_id)
+      local nginx = require "nginx"
+      assert.are.equal(user_id, nginx.authenticate({ auth = auth_mock }, { [auth.ACCESS_TOKEN_HEADER] = "abcd" }))
     end)
   end)
 end)

--- a/spec/nginx_spec.lua
+++ b/spec/nginx_spec.lua
@@ -1,4 +1,5 @@
 local globals = require "test.helpers.globals"
+local cookie = require "cookie"
 local auth = require "auth"
 local auth_mock = require "mocks.auth"
 
@@ -34,7 +35,7 @@ describe("nginx module tests", function()
       assert.stub(ngx.exec).was.called_with("@service")
 
       assert.stub(ngx.req.set_header).was_called_with(auth.USER_ID_HEADER, user_id)
-      assert.stub(ngx.req.set_header).was_called_with("Cookie", "")
+      assert.stub(ngx.req.set_header).was_called_with(cookie.COOKIE_HEADER, "")
     end)
 
     it("will clear the user id header when the user id is not supplied", function()
@@ -45,7 +46,7 @@ describe("nginx module tests", function()
       assert.stub(ngx.exec).was.called_with("@service")
 
       assert.stub(ngx.req.set_header).was_called_with(auth.USER_ID_HEADER, "")
-      assert.stub(ngx.req.set_header).was_called_with("Cookie", "")
+      assert.stub(ngx.req.set_header).was_called_with(cookie.COOKIE_HEADER, "")
     end)
 
   end)
@@ -53,21 +54,21 @@ describe("nginx module tests", function()
   describe("authenticate using cookie tests", function()
     it("returns nil when the cookie_string is nil", function()
       local nginx = require "nginx"
-      assert.are.equal(nil, nginx.authenticate({}, { ["Cookie"] = nil }))
-      assert.are.equal(nil, nginx.authenticate({}, { ["Cookie"] = "" }))
+      assert.are.equal(nil, nginx.authenticate({}, { [cookie.COOKIE_HEADER] = nil }))
+      assert.are.equal(nil, nginx.authenticate({}, { [cookie.COOKIE_HEADER] = "" }))
     end)
 
     it("returns nil when authenticate returns nil", function()
       local auth = auth_mock:new(nil)
       local nginx = require "nginx"
-      assert.are.equal(nil, nginx.authenticate({ auth = auth }, { ["Cookie"] = "foo=abcd" }))
+      assert.are.equal(nil, nginx.authenticate({ auth = auth }, { [cookie.COOKIE_HEADER] = "foo=abcd" }))
     end)
 
     it("returns the user id provided by authenticate", function()
       local user_id = 12345;
       local auth = auth_mock:new(user_id)
       local nginx = require "nginx"
-      assert.are.equal(user_id, nginx.authenticate({ auth = auth }, { ["Cookie"] = "foo=abcd" }))
+      assert.are.equal(user_id, nginx.authenticate({ auth = auth }, { [cookie.COOKIE_HEADER] = "foo=abcd" }))
     end)
   end)
 

--- a/spec_integration/service_auth_spec.lua
+++ b/spec_integration/service_auth_spec.lua
@@ -1,0 +1,43 @@
+local client = require('httpclient').new()
+local cjson = require "cjson"
+local auth = require "auth"
+
+local USERNAME = os.getenv("USERNAME")
+local PASSWORD = os.getenv("PASSWORD")
+local LOGIN_URL = os.getenv("LOGIN_URL") or "https://services.wikia.com/helios/token"
+local SERVICE_URL = os.getenv("SERVICE_URL")
+
+
+client:set_default("ssl_opts", { ["verify"] = "none" })
+
+function login(url, username, password)
+  res = client:post(url, string.format("username=%s&password=%s", username, password),
+  { ["headers"] = { ["Content-Type"] = "application/x-www-form-urlencoded" } })
+  status, data = pcall(function() return cjson.new().decode(res.body) end)
+  if status and data and data.user_id then
+    return data
+  end
+
+  return nil
+end
+
+describe("try login", function()
+  it("login is successful", function()
+    local response = login(LOGIN_URL, USERNAME, PASSWORD)
+    assert.truthy(response)
+    assert.truthy(tonumber(response.user_id) > 0)
+    assert.truthy(response.access_token)
+  end)
+end)
+  
+describe("authenticated request", function()
+  before_each(function()
+    user = login(LOGIN_URL, USERNAME, PASSWORD)
+  end)
+
+  it("service request is successful", function()
+    local response = client:get(SERVICE_URL, { ["headers"] = { [auth.ACCESS_TOKEN_HEADER] = user.access_token } })
+    assert.truthy(response)
+    assert.are.equal(200, response.code)
+  end)
+end)

--- a/src/auth.lua
+++ b/src/auth.lua
@@ -1,8 +1,11 @@
 -- package auth
 
 local USER_ID_HEADER = "X-Wikia-UserId"
+local ACCESS_TOKEN_HEADER = "X-Wikia-AccessToken"
+
 local auth = {
   USER_ID_HEADER = USER_ID_HEADER,
+  ACCESS_TOKEN_HEADER = ACCESS_TOKEN_HEADER,
 }
 
 local cookie = require "cookie"
@@ -29,7 +32,7 @@ function auth:authenticate_and_return_user_id(access_token)
   return nil
 end
 
-function auth:authenticate(cookie_string)
+function auth:authenticate_by_cookie(cookie_string)
   if not cookie_string then
     return nil
   end

--- a/src/cookie.lua
+++ b/src/cookie.lua
@@ -1,6 +1,10 @@
 -- package cookie: naive cookie parsing
 -- basic functionality from https://github.com/frodsan/cookie.lua/blob/master/cookie.lua
-local cookie = {}
+local COOKIE_HEADER = "Cookie"
+
+local cookie = {
+	COOKIE_HEADER = COOKIE_HEADER,
+}
 
 local gmatch = string.gmatch
 local sub    = string.sub

--- a/src/mocks/auth.lua
+++ b/src/mocks/auth.lua
@@ -10,7 +10,11 @@ function auth:new(authenticate_response)
   return setmetatable(out, { __index = self })
 end
 
-function auth:authenticate(cookie_string)
+function auth:authenticate_by_cookie(cookie_string)
+  return self.authenticate_response
+end
+
+function auth:authenticate_and_return_user_id(cookie_string)
   return self.authenticate_response
 end
 
@@ -19,4 +23,3 @@ function auth:set_authenticate_response(response)
 end
 
 return auth
-

--- a/src/nginx.lua
+++ b/src/nginx.lua
@@ -38,14 +38,26 @@ function nginx.healthcheck(app)
   end
 end
 
-function nginx.authenticate(app, cookie_string)
-  if not cookie_string or cookie_string == "" then
+function nginx.authenticate(app, headers)
+  local user_id = nil
+  if type(headers) ~= "table" then
     return nil
   end
 
-  local user_id = app.auth:authenticate(cookie_string)
-  if user_id then
-    return user_id
+  local cookie_string = headers["Cookie"]
+  if cookie_string and cookie_string ~= "" then
+    user_id = app.auth:authenticate_by_cookie(cookie_string)
+    if user_id then
+      return user_id
+    end
+  end
+
+  local token = headers[auth.ACCESS_TOKEN_HEADER]
+  if token and token ~= "" then
+    user_id = app.auth:authenticate_and_return_user_id(token)
+    if user_id then
+      return user_id
+    end
   end
 
   return nil

--- a/src/nginx.lua
+++ b/src/nginx.lua
@@ -44,7 +44,7 @@ function nginx.authenticate(app, headers)
     return nil
   end
 
-  local cookie_string = headers["Cookie"]
+  local cookie_string = headers[cookie.COOKIE_HEADER]
   if cookie_string and cookie_string ~= "" then
     user_id = app.auth:authenticate_by_cookie(cookie_string)
     if user_id then
@@ -73,7 +73,7 @@ function nginx.service_proxy(ngx, user_id)
   end
 
   -- clear the cookie; it should not be sent to the backend
-  ngx.req.set_header("Cookie", "")
+  ngx.req.set_header(cookie.COOKIE_HEADER, "")
 
   return ngx.exec("@service")
 end


### PR DESCRIPTION
Add support for authentication via X-Wikia-AccessToken. This supplements the `access_token` cookie to enable authenticated request support for mobile applications. See https://wikia-inc.atlassian.net/browse/SERVICES-399.

/cc @Wikia/services-team 