### PR TITLE
[SERVICES-531] Added explicit access controll allow methods

### DIFF
--- a/src/cors.lua
+++ b/src/cors.lua
@@ -14,7 +14,7 @@ local cors = {
   allow_credentials_header = "Access-Control-Allow-Credentials",
 
   allow_headers_default_value = "*",
-  allow_methods_default_value = "*",
+  allow_methods_default_value = "POST,GET,OPTIONS,PUT,DELETE",
   allow_credentials_default_value = "true",
 
 }


### PR DESCRIPTION
Access-Control-Allow-Methods need to be passed explicitly as wildcard don't work properly with preflighted requests that use OPTIONS method.

/cc @Wikia/services-team @pchojnacki @bkoval @kvas-damian 