### PR TITLE
Make travis use containers and rockspec to build and test the api-gateway

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: lua
+<<<<<<< HEAD
 install:
   - sudo apt-get update
   - sudo apt-get install openssl
@@ -10,4 +11,21 @@ install:
   - sudo luarocks install busted 2.0.rc10-0
   - sudo luarocks install lua-cjson 2.1.0-1
   - sudo luarocks install httpclient 0.1.0-7
+=======
+addons:
+  apt:
+    packages:
+    - cmake
+    - libssl-dev
+    - luajit
+    - luarocks
+    - lua-resty-http
+
+install:  
+  - luarocks install lua-resty-http
+  - luarocks install luasec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu/
+  - luarocks install busted
+  - luarocks install lua-cjson
+  - luarocks install httpclient
+>>>>>>> travis fix
 script: "busted spec"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,5 @@
 language: lua
-<<<<<<< HEAD
-install:
-  - sudo apt-get update
-  - sudo apt-get install openssl
-  - sudo apt-get install libssl-dev
-  - sudo apt-get install luajit
-  - sudo apt-get install luarocks
-  - sudo luarocks install lua-resty-http 0.06-0
-  - sudo luarocks install luasec 0.5-2 OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu/
-  - sudo luarocks install busted 2.0.rc10-0
-  - sudo luarocks install lua-cjson 2.1.0-1
-  - sudo luarocks install httpclient 0.1.0-7
-=======
+sudo: false
 addons:
   apt:
     packages:
@@ -22,10 +10,5 @@ addons:
     - lua-resty-http
 
 install:  
-  - luarocks install lua-resty-http
-  - luarocks install luasec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu/
-  - luarocks install busted
-  - luarocks install lua-cjson
-  - luarocks install httpclient
->>>>>>> travis fix
-script: "busted spec"
+  - luarocks build api_gateway-0.1-0.rockspec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu --local
+script: "~/.luarocks/bin/busted spec"

--- a/api_gateway-0.1-0.rockspec
+++ b/api_gateway-0.1-0.rockspec
@@ -15,7 +15,7 @@ build = {
 
 dependencies = {
    "lua-resty-http = 0.06-0",
-   "busted = 2.0.rc9-0",
+   "busted = 2.0.rc10-0",
    "lua-cjson = 2.1.0-1",
    "httpclient = 0.1.0-7",
 }

--- a/api_gateway-0.1-0.rockspec
+++ b/api_gateway-0.1-0.rockspec
@@ -1,17 +1,21 @@
-package = "api-gateway"
-local VER = "1.0"
-version = VER .. "-1"
+package = "api_gateway"
+local VER = "0.1"
+version = VER .. "-0"
 
 source = {
-  url = "https://github.com/Wikia/api-gateway.git",
+  url = "file://src",
 }
 description = {
 	license = "PRIVATE",
 }
 
+build = {
+  type = "command"
+}
+
 dependencies = {
    "lua >= 5.3",
-   "lua-resty-http = 0.1-0",
+   "lua-resty-http = 0.06-0",
    "busted = 2.0.rc9-0",
    "lua-cjson = 2.1.0-1",
    "httpclient = 0.1.0-7",

--- a/api_gateway-0.1-0.rockspec
+++ b/api_gateway-0.1-0.rockspec
@@ -14,7 +14,6 @@ build = {
 }
 
 dependencies = {
-   "lua >= 5.3",
    "lua-resty-http = 0.06-0",
    "busted = 2.0.rc9-0",
    "lua-cjson = 2.1.0-1",

--- a/rockspec
+++ b/rockspec
@@ -1,0 +1,18 @@
+package = "api-gateway"
+local VER = "1.0"
+version = VER .. "-1"
+
+source = {
+  url = "https://github.com/Wikia/api-gateway.git",
+}
+description = {
+	license = "PRIVATE",
+}
+
+dependencies = {
+   "lua >= 5.3",
+   "lua-resty-http = 0.1-0",
+   "busted = 2.0.rc9-0",
+   "lua-cjson = 2.1.0-1",
+   "httpclient = 0.1.0-7",
+}


### PR DESCRIPTION
Using rockspec allows for standard way to install all dependencies of the project.
Additionally travis introduced newer faster way to build applications.
This travis config change enables faster builds and hence shorter turnaround time for PRs