### PR TITLE
Make /helios & /auth synonymous

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - sudo apt-get install libssl-dev
   - sudo apt-get install luajit
   - sudo apt-get install luarocks
-  - sudo luarocks install lua-resty-http
+  - sudo luarocks install lua-resty-http 0.1-0
   - sudo luarocks install luasec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu/
   - sudo luarocks install busted
   - sudo luarocks install lua-cjson

--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -13,26 +13,21 @@ server {
     content_by_lua 'ngx.say("OK")';
   }
 
-  location ~ ^/helios/(register|users|facebook/users) {
+  location ~ ^/(helios|auth)/(register|users|facebook/users) {
     limit_req zone=registration burst=2 nodelay;
-    proxy_pass http://prod_helios/$stripped_uri;
-  }
-
-  location /helios {
-    proxy_pass http://prod_helios/$stripped_uri;
+    proxy_pass_request_headers off;
+    content_by_lua '
+      local router = require("nginx/router")
+      return router.route()
+      ';
   }
 
   location / {
     rewrite ^/service/(.*)$ /$1 break;
     proxy_pass_request_headers off;
     content_by_lua '
-      local config = require("config")
-      local nginx = require("nginx")
-      local app = nginx.init(config)
-
-      local headers = ngx.req.get_headers(100)
-      local user_id = nginx.authenticate(app, headers)
-      return nginx.service_proxy(ngx, user_id)
+      local router = require("nginx/router")
+      return router.route()
       ';
   }
 

--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -13,7 +13,7 @@ server {
     content_by_lua 'ngx.say("OK")';
   }
 
-  location ~ ^/(helios|auth)/(register|users|facebook/users) {
+  location ~ ^/(helios|auth)/(users|facebook/users) {
     limit_req zone=registration burst=2 nodelay;
     proxy_pass_request_headers off;
     content_by_lua '

--- a/src/nginx/router.lua
+++ b/src/nginx/router.lua
@@ -1,0 +1,17 @@
+-- package router: A wrapper for routing requests
+
+local router = {}
+
+local config = require "config"
+local nginx = require "nginx"
+
+function router.route()
+  local app = nginx.init(config)
+
+  local headers = ngx.req.get_headers(100)
+  local user_id = nginx.authenticate(app, headers)
+  return nginx.service_proxy(ngx, user_id)
+end
+
+
+return router


### PR DESCRIPTION
This merges /helios and & /auth under one route while keeping the rate limiting intact. I also created a helper to simplify the request routing and reduce the duplicated code between the service route and the helios specific route.

This assumes that both `helios` and `auth` are configured in consul for the API gateway. But otherwise they both use the same routing mechanism as every other service.

https://wikia-inc.atlassian.net/browse/SERVICES-568
https://wikia-inc.atlassian.net/browse/SERVICES-555

/cc @Wikia/services-team @pchojnacki 