### PR TITLE
also clear the access token header when forwarding a request to services

### DIFF
--- a/src/nginx.lua
+++ b/src/nginx.lua
@@ -64,6 +64,7 @@ function nginx.service_proxy(ngx, user_id)
 
   -- clear the cookie; it should not be sent to the backend
   ngx.req.set_header(cookie.COOKIE_HEADER, "")
+  ngx.req.set_header(auth.ACCESS_TOKEN_HEADER, "")
 
   return ngx.exec("@service")
 end


### PR DESCRIPTION
@Wikia/services-team 

also clear out the `X-Wikia-AccessToken` header when forwarding requests to services