### PR TITLE
SOC-1268/SOC-1317 explicitly list allowed headers. * is not working on both chrome and FF

### DIFF
--- a/src/cors.lua
+++ b/src/cors.lua
@@ -13,7 +13,7 @@ local cors = {
   allow_methods_header = "Access-Control-Allow-Methods",
   allow_credentials_header = "Access-Control-Allow-Credentials",
 
-  allow_headers_default_value = "*",
+  allow_headers_default_value = "Content-Type, Accept",
   allow_methods_default_value = "POST,GET,OPTIONS,PUT,DELETE",
   allow_credentials_default_value = "true",
 


### PR DESCRIPTION
@bkoval reported an issue with sending specific content type to clickstream from browser.

This PR should address this issue
Todo:
- [x] test on dev