### PR TITLE
Set the WIKIA_ENVIRONMENT to a sane default

### DIFF
--- a/scripts/templatize
+++ b/scripts/templatize
@@ -9,6 +9,10 @@ if [[ -z $CONSUL_URI ]]; then
 	echo Usage: scripts/templatize localhost:8500
 	exit 1
 fi
+
+if [[ -z $WIKIA_ENVIRONMENT ]]; then
+  export WIKIA_ENVIRONMENT="dev"
+fi
 consul-template -consul $CONSUL_URI\
   -log-level=info\
   -template "$WORKING/templates/src/config.lua:$WORKING/src/config.lua"\


### PR DESCRIPTION
This is solely for the scripts/templatize helper. If you don't have `WIKIA_ENVIRONMENT` set the template building won't work because the KV path won't be properly constructed.

