### PR TITLE
Add /auth/token to the rate limiting

### DIFF
--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -13,7 +13,7 @@ server {
     content_by_lua 'ngx.say("OK")';
   }
 
-  location ~ ^/(helios|auth)/(users|facebook/users) {
+  location ~ ^/(helios|auth)/(token|users|facebook/users) {
     limit_req zone=registration burst=2 nodelay;
     proxy_pass_request_headers off;
     content_by_lua '


### PR DESCRIPTION
The `/auth/token` path was not part of the rate limiting in the API gateway. 

https://wikia-inc.atlassian.net/browse/SERVICES-667

@Wikia/services-team 