### PR TITLE
Deny access to user specific token resources

### DIFF
--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -13,6 +13,10 @@ server {
     content_by_lua 'ngx.say("OK")';
   }
 
+  location /helios {
+    deny all;
+  }
+
   location /auth {
     limit_req zone=registration burst=2 nodelay;
     proxy_pass_request_headers off;

--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -21,7 +21,7 @@ server {
     limit_req zone=registration burst=2 nodelay;
     proxy_pass_request_headers off;
 
-    location ~ /auth/users/(\w+)/tokens {
+    location ~ ^/auth/users/(\w+)/tokens {
       deny all;
     }
 

--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -13,9 +13,14 @@ server {
     content_by_lua 'ngx.say("OK")';
   }
 
-  location ~ ^/(helios|auth)/(token|users|facebook/users) {
+  location /auth {
     limit_req zone=registration burst=2 nodelay;
     proxy_pass_request_headers off;
+
+    location ~ /auth/users/(\w+)/tokens {
+      deny all;
+    }
+
     content_by_lua '
       local router = require("nginx/router")
       return router.route()


### PR DESCRIPTION
This PR denies access to user specific token resources under `/auth/users/(\w+)/tokens`. As part of this change I also simplified the handling of `/auth` by nesting the related logic and removing `/helios`. I also explicitly deny access to `/helios` just to be sure there is no way around the other restrictions on `/auth.

https://wikia-inc.atlassian.net/browse/SERVICES-894