### PR TITLE
Restore explicit rate limiting

### DIFF
--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -26,7 +26,7 @@ server {
       deny all;
     }
 
-    # FIXME: See above. These too should not be special cased, but until we
+    # FIXME: See above. These too should not be special cased. But, until we
     # can separate this functionality we need to do our best to prevent abuse.
     location ~ ^/auth/(token|users|facebook/users) {
       limit_req zone=registration burst=2 nodelay;

--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -18,13 +18,23 @@ server {
   }
 
   location /auth {
-    limit_req zone=registration burst=2 nodelay;
-    proxy_pass_request_headers off;
+     proxy_pass_request_headers off;
 
     # FIXME: This is not intended to be a long term solution. Remove once
     # authentication is separated from helios and is internal only.
     location ~ ^/auth/users/(\w+)/tokens {
       deny all;
+    }
+
+    # FIXME: See above. These too should not be special cased, but until we
+    # can separate this functionality we need to do our best to prevent abuse.
+    location ~ ^/auth/(token|users|facebook/users) {
+      limit_req zone=registration burst=2 nodelay;
+
+      content_by_lua '
+        local router = require("nginx/router")
+        return router.route()
+        ';
     }
 
     content_by_lua '

--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -18,7 +18,7 @@ server {
   }
 
   location /auth {
-     proxy_pass_request_headers off;
+    proxy_pass_request_headers off;
 
     # FIXME: This is not intended to be a long term solution. Remove once
     # authentication is separated from helios and is internal only.


### PR DESCRIPTION
Restored rate limiting only on `/auth/(token|users|facebook/users)` instead of rate limiting all of `/auth`. Upon deploy of the previous release we discovered that there are some `/auth` paths (e.g. username and token validation) that were being rate limited.

https://wikia-inc.atlassian.net/browse/SERVICES-894

/cc @Wikia/services-team 