### PR TITLE
Block /auth/info

### DIFF
--- a/api_gateway-0.1-0.rockspec
+++ b/api_gateway-0.1-0.rockspec
@@ -15,7 +15,7 @@ build = {
 
 dependencies = {
    "lua-resty-http = 0.06-0",
-   "busted = 2.0.rc10-0",
+   "busted = 2.0.rc11-0",
    "lua-cjson = 2.1.0-1",
    "httpclient = 0.1.0-7",
 }

--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -22,7 +22,7 @@ server {
 
     # FIXME: This is not intended to be a long term solution. Remove once
     # authentication is separated from helios and is internal only.
-    location ~ ^/auth/users/(\w+)/tokens {
+    location ~ ^/auth/(info|users/(\w+)/tokens) {
       deny all;
     }
 


### PR DESCRIPTION
Block `/auth/info` in the gateway. Token validation should now be internal only now that we have the whoami service (available via `/whoami`).

https://wikia-inc.atlassian.net/browse/SERVICES-885

@Wikia/services-team @kvas-damian 