### PR TITLE
Add support for handling cookies as a table of cookies

### DIFF
--- a/api_gateway-0.1-0.rockspec
+++ b/api_gateway-0.1-0.rockspec
@@ -15,7 +15,7 @@ build = {
 
 dependencies = {
    "lua-resty-http = 0.06-0",
-   "busted = 2.0.rc10-0",
+   "busted = 2.0.rc11-0",
    "lua-cjson = 2.1.0-1",
    "httpclient = 0.1.0-7",
 }

--- a/spec/auth_spec.lua
+++ b/spec/auth_spec.lua
@@ -63,4 +63,38 @@ describe("authentication tests", function()
 		end)
 
 	end)
+
+	describe("multiple cookie header parsing", function()
+		before_each(function()
+			cookie_strings_first = {"access_token=1234; other_value=abced\"", "foo=bar; something=otherthing;"}
+			cookie_strings_second = {"foo=bar; something=otherthing;", "access_token=1234; other_value=abced\""}
+		end)
+
+		it("tests that we can handle a table with no token", function()
+			local helios = helios:new(expected_user_id)
+
+			local auth_client = auth:new(helios)
+
+			local user_id = auth_client:authenticate_by_cookie({"foo=bar; a=b", "b=a; bar=foo"})
+			assert.are.equal(nil, user_id)
+		end)
+
+		it("tests that we can handle a table with the token in the first element", function()
+			local helios = helios:new(expected_user_id)
+
+			local auth_client = auth:new(helios)
+
+			local user_id = auth_client:authenticate_by_cookie(cookie_strings_first)
+			assert.are.equal(expected_user_id, user_id)
+		end)
+
+		it("tests that we can handle a table with the token in the second element", function()
+			local helios = helios:new(expected_user_id)
+
+			local auth_client = auth:new(helios)
+
+			local user_id = auth_client:authenticate_by_cookie(cookie_strings_second)
+			assert.are.equal(expected_user_id, user_id)
+		end)
+	end)
 end)

--- a/src/auth.lua
+++ b/src/auth.lua
@@ -46,6 +46,9 @@ function auth:authenticate_by_cookie(cookie_thing)
     return nil
   end
 
+  -- if there are multiple 'Cookie' headers then ngx.req.headers()['Cookie']
+  -- will be a table (array)
+  -- see https://github.com/openresty/lua-nginx-module#ngxreqget_headers
   if is_table(cookie_thing) then
     for _, cookie_string in ipairs(cookie_thing) do
       local user_id = self:access_token_to_user_id(cookie_string)

--- a/src/auth.lua
+++ b/src/auth.lua
@@ -32,7 +32,7 @@ function auth:authenticate_and_return_user_id(access_token)
   return nil
 end
 
-function auth:access_token_to_user_id(cookie_string)
+function auth:cookie_string_to_user_id(cookie_string)
   local cookie_map = cookie.parse(cookie_string)
   if cookie_map.access_token then
     return self:authenticate_and_return_user_id(cookie_map.access_token)
@@ -51,13 +51,13 @@ function auth:authenticate_by_cookie(cookie_thing)
   -- see https://github.com/openresty/lua-nginx-module#ngxreqget_headers
   if is_table(cookie_thing) then
     for _, cookie_string in ipairs(cookie_thing) do
-      local user_id = self:access_token_to_user_id(cookie_string)
+      local user_id = self:cookie_string_to_user_id(cookie_string)
       if user_id then
         return user_id
       end
     end
   else
-    return self:access_token_to_user_id(cookie_thing)
+    return self:cookie_string_to_user_id(cookie_thing)
   end
 end
 

--- a/src/auth.lua
+++ b/src/auth.lua
@@ -41,23 +41,23 @@ function auth:cookie_string_to_user_id(cookie_string)
   return nil
 end
 
-function auth:authenticate_by_cookie(cookie_thing)
-  if not cookie_thing then
+function auth:authenticate_by_cookie(cookie_container)
+  if not cookie_container then
     return nil
   end
 
   -- if there are multiple 'Cookie' headers then ngx.req.headers()['Cookie']
   -- will be a table (array)
   -- see https://github.com/openresty/lua-nginx-module#ngxreqget_headers
-  if is_table(cookie_thing) then
-    for _, cookie_string in ipairs(cookie_thing) do
+  if is_table(cookie_container) then
+    for _, cookie_string in ipairs(cookie_container) do
       local user_id = self:cookie_string_to_user_id(cookie_string)
       if user_id then
         return user_id
       end
     end
   else
-    return self:cookie_string_to_user_id(cookie_thing)
+    return self:cookie_string_to_user_id(cookie_container)
   end
 end
 

--- a/src/auth.lua
+++ b/src/auth.lua
@@ -32,20 +32,34 @@ function auth:authenticate_and_return_user_id(access_token)
   return nil
 end
 
-function auth:authenticate_by_cookie(cookie_string)
-  if not cookie_string then
-    return nil
-  end
-
+function auth:access_token_to_user_id(cookie_string)
   local cookie_map = cookie.parse(cookie_string)
   if cookie_map.access_token then
-    local user_id = self:authenticate_and_return_user_id(cookie_map.access_token)
-    if user_id then
-      return user_id
-    end
+    return self:authenticate_and_return_user_id(cookie_map.access_token)
   end
 
   return nil
+end
+
+function auth:authenticate_by_cookie(cookie_thing)
+  if not cookie_thing then
+    return nil
+  end
+
+  if is_table(cookie_thing) then
+    for _, cookie_string in ipairs(cookie_thing) do
+      local user_id = self:access_token_to_user_id(cookie_string)
+      if user_id then
+        return user_id
+      end
+    end
+  else
+    return self:access_token_to_user_id(cookie_thing)
+  end
+end
+
+function is_table(thing)
+  return type(thing) == "table"
 end
 
 return auth


### PR DESCRIPTION
If multiple `Cookie` headers are provided in the request `ngx.req.headers()['Cookie']` will return a table (array) with each element being the cookie string that was supplied in each header. This PR adds support for table (array) handling of `Cookie` headers.

https://wikia-inc.atlassian.net/browse/SERVICES-1054

@Wikia/services-team 