### PR TITLE
WIP: Pass through the Fastly-Client-IP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ nginx/production/upstreams.conf
 src/configured_locations.lua
 t/lua
 t/servroot
+tmp/
+.R*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ src/config.lua
 nginx/logs
 nginx/production/upstreams.conf
 src/configured_locations.lua
+t/lua
+t/servroot

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ addons:
     - lua-resty-http
     - openresty
     - cpanminus
+env:
+  - PERL5LIB=$HOME/perl5
 
 install:  
   - luarocks build api_gateway-0.1-0.rockspec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu --local
-  - cpanm install Test::Nginx::Socket
+  - cpanm --local-lib=$HOME/perl5 install Test::Nginx::Socket
 script: ./scripts/run-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ addons:
     - luarocks
     - lua-resty-http
     - openresty
+    - cpanminus
 
 install:  
   - luarocks build api_gateway-0.1-0.rockspec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu --local
-  - cpan install Test::Nginx::Socket
+  - cpanm install Test::Nginx::Socket
 script: ./scripts/run-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ addons:
     - libssl-dev
     - luajit
     - luarocks
-    - lua-resty-http
-    - openresty
     - cpanminus
+
 env:
-  - PERL5LIB=$HOME/perl5
+  - PERL5LIB=$HOME/perl5/lib/perl5
 
 install:  
   - luarocks build api_gateway-0.1-0.rockspec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu --local

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,5 @@ install:
   - cpanm --local-lib=$HOME/perl5 install Test::Nginx::Socket
 script:
   - ./scripts/install-openresty.sh
+  - ./scripts/install-luarocks.sh
   - ./scripts/run-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
 
 env:
   - PERL5LIB=$HOME/perl5/lib/perl5
+  - LUAJIT_PATH=$HOME/local/luajit/
 
 install:  
   - luarocks build api_gateway-0.1-0.rockspec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu --local

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ addons:
 
 
 env:
-  - PERL5LIB=$HOME/perl5/lib/perl5
-  - LUAJIT_PATH=$HOME/local/luajit/
+  - PERL5LIB=$HOME/perl5/lib/perl5 LUAJIT_PATH=$HOME/local/luajit/
 
 install:  
   - luarocks build api_gateway-0.1-0.rockspec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu --local

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ addons:
     - luajit
     - luarocks
     - lua-resty-http
+    - openresty
 
 install:  
   - luarocks build api_gateway-0.1-0.rockspec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu --local
-script: "~/.luarocks/bin/busted spec"
+  - cpan install Test::Nginx::Socket
+script: ./scripts/run-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ addons:
     - luajit
     - luarocks
     - cpanminus
+    - libreadline-dev
+    - libncurses5-dev
+    - libpcre3-dev
+    - libssl-dev
+    - perl
+    - make
+    - build-essential
+
 
 env:
   - PERL5LIB=$HOME/perl5/lib/perl5
@@ -15,4 +23,6 @@ env:
 install:  
   - luarocks build api_gateway-0.1-0.rockspec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu --local
   - cpanm --local-lib=$HOME/perl5 install Test::Nginx::Socket
-script: ./scripts/run-tests.sh
+script:
+  - ./scripts/install-openresty.sh
+  - ./scripts/run-tests.sh

--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ dt push -a api-gateway -e prod
  * [nginx](http://nginx.org/)
  * [consul-template](https://github.com/hashicorp/consul-template)
 
+## Installing luarocks & openresty Dependencies
+
+ ```
+ export LUAJIT_PATH=/usr/local/Cellar/openresty/1.7.10.1/luajit # set to your local path
+ wget http://luarocks.org/releases/luarocks-2.0.11.tar.gz
+ tar -xzvf luarocks-2.0.11.tar.gz
+ cd luarocks-2.0.13/
+ ./configure --prefix=$LUAJIT_PATH \
+     --with-lua=$LUAJIT_PATH \
+		 --lua-suffix=jit-2.1.0-alpha \
+	   --with-lua-include=$LUAJIT_PATH/include/luajit-2.1
+ make
+ make install
+ ```
+
 ## Environement variables
 
  * `NGINX_BIN`: Set to the location of your nginx binary.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,21 @@ gateway.
 
 ## Testing
 
-This package is tested using [busted](http://olivinelabs.com/busted/). To run the tests do
+The lua source code is tested using [busted](http://olivinelabs.com/busted/). To run the tests do
 the following:
 
 ```
 busted spec
 ```
+
+The lua+nginx integration is tested using `Test::Nginx::Socket`. To run the
+tests, set `TEST_NGINX_BINARY` (see the Environment section below) and execute:
+
+```
+prove -r t/
+```
+
+See `t/basic.t` for the Perl dependencies and example code.
 
 ## Local Integration Testing
 
@@ -149,6 +158,9 @@ dt push -a api-gateway -e prod
 ## Environement variables
 
  * `NGINX_BIN`: Set to the location of your nginx binary.
+ * `TEST_NGINX_BINARY`: Set to the location of nginx.
+		E.g. `export TEST_NGINX_BINARY=`which openresty` on OS X.
+ * `API_GATEWAY_TEST_MOCK`: Set to change the default api-gateway test mock.
 
 ## Contributors
 

--- a/scripts/install-luarocks.sh
+++ b/scripts/install-luarocks.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+VERSION=2.0.11
+PACKAGE=luarocks-${VERSION}.tar.gz
+LUAJIT_PATH=${LUAJIT_PATH-/usr/local/openresty/luajit}
+TEMPDIR=$HOME/tmp
+PREFIX=$HOME/local
+
+mkdir -p $TEMPDIR
+mkdir -p $PREFIX
+
+cd $TEMPDIR
+rm -rf luarocks-${VERSION}/
+
+wget http://luarocks.org/releases/$PACKAGE
+tar -xzvf $PACKAGE
+cd luarocks-${VERSION}/
+./configure --prefix=$LUAJIT_PATH \
+    --with-lua=$LUAJIT_PATH \
+    --lua-suffix=jit-2.1.0-alpha \
+    --with-lua-include=$LUAJIT_PATH/include/luajit-2.1
+make
+make install
+$LUAJIT_PATH/bin/luarocks install lua-resty-http

--- a/scripts/install-openresty.sh
+++ b/scripts/install-openresty.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+VERSION=1.7.10.2
+PACKAGE=ngx_openresty-${VERSION}.tar.gz
+DOWNLOAD_BASE=https://openresty.org/download
+TEMPDIR=$HOME/tmp
+PREFIX=$HOME/local
+
+mkdir -p $TEMPDIR
+mkdir -p $PREFIX
+
+
+cd $TEMPDIR
+wget $DOWNLOAD_BASE/$PACKAGE
+tar zxvf $PACKAGE
+
+cd ngx_openresty-${VERSION}
+./configure --prefix=$HOME/local
+make
+make install
+

--- a/scripts/install-openresty.sh
+++ b/scripts/install-openresty.sh
@@ -10,6 +10,8 @@ mkdir -p $PREFIX
 
 
 cd $TEMPDIR
+rm -rf ngx_openresty-${VERSION}
+
 wget $DOWNLOAD_BASE/$PACKAGE
 tar zxvf $PACKAGE
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 export PATH=$PATH:$HOME/.luarocks/bin:$HOME/local/nginx/sbin
-export TEST_NGINX_BINARY=`which openresty`
+NGINX_BIN=$(which openresty)
+if [ -z $NGINX_BIN ]; then
+    NGINX_BIN=$(which nginx)
+fi
+export TEST_NGINX_BINARY=$NGINX_BIN
 busted spec && prove -r t

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -4,5 +4,6 @@ NGINX_BIN=$(which openresty)
 if [ -z $NGINX_BIN ]; then
     NGINX_BIN=$(which nginx)
 fi
+echo "*** Found nginx under '${NGINX_BIN}' *** "
 export TEST_NGINX_BINARY=$NGINX_BIN
 busted spec && prove -r t

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export PATH=$PATH:$HOME/.luarocks/bin
+export TEST_NGINX_BINARY=`which openresty`
+busted spec && prove -r t

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -12,4 +12,5 @@ busted spec
 prove -r t
 if [ $? -ne 0 ]; then
     cat $PWD/t/servroot/logs/error.log
+    exit 1
 fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-export PATH=$PATH:$HOME/.luarocks/bin
+export PATH=$PATH:$HOME/.luarocks/bin:$HOME/local/bin
 export TEST_NGINX_BINARY=`which openresty`
-/bin/ls -R $PERL5LIB/lib/perl5/
 busted spec && prove -r t

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -5,5 +5,6 @@ if [ -z $NGINX_BIN ]; then
     NGINX_BIN=$(which nginx)
 fi
 echo "*** Found nginx under '${NGINX_BIN}' *** "
+$NGINX_BIN -v
 export TEST_NGINX_BINARY=$NGINX_BIN
 busted spec && prove -r t

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 export PATH=$PATH:$HOME/.luarocks/bin
 export TEST_NGINX_BINARY=`which openresty`
+/bin/ls -R $PERL5LIB/lib/perl5/
 busted spec && prove -r t

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 export PATH=$PATH:$HOME/.luarocks/bin:$HOME/local/nginx/sbin
-NGINX_BIN=$(which openresty)
-if [ -z $NGINX_BIN ]; then
-    NGINX_BIN=$(which nginx)
+if [ $(uname) == "Darwin" ]; then
+    NGINX_BIN=$(which openresty)
+    if [ -z $NGINX_BIN ]; then
+        NGINX_BIN=$(which nginx)
+    fi
+    export TEST_NGINX_BINARY=$NGINX_BIN
 fi
-echo "*** Found nginx under '${NGINX_BIN}' *** "
-$NGINX_BIN -v
-export TEST_NGINX_BINARY=$NGINX_BIN
 busted spec && prove -r t

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -7,4 +7,9 @@ if [ $(uname) == "Darwin" ]; then
     fi
     export TEST_NGINX_BINARY=$NGINX_BIN
 fi
-busted spec && prove -r t
+
+busted spec
+prove -r t
+if [ $? -ne 0 ]; then
+    cat $PWD/t/servroot/logs/error.log
+fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-export PATH=$PATH:$HOME/.luarocks/bin:$HOME/local/bin
+export PATH=$PATH:$HOME/.luarocks/bin:$HOME/local/nginx/sbin
 export TEST_NGINX_BINARY=`which openresty`
 busted spec && prove -r t

--- a/spec/nginx_spec.lua
+++ b/spec/nginx_spec.lua
@@ -32,7 +32,7 @@ describe("nginx module tests", function()
     it("will set the user id header when supplied", function()
       local nginx = require "nginx"
       local user_id = 1234;
-      local ret = nginx.service_proxy(ngx, user_id)
+      local ret = nginx.service_proxy(ngx, user_id, {})
 
       assert.stub(ngx.exec).was.called_with("@service")
 
@@ -43,7 +43,7 @@ describe("nginx module tests", function()
     it("will clear the user id header when the user id is not supplied", function()
       local nginx = require "nginx"
       local user_id = nil;
-      local ret = nginx.service_proxy(ngx, user_id)
+      local ret = nginx.service_proxy(ngx, user_id, {})
 
       assert.stub(ngx.exec).was.called_with("@service")
 

--- a/src/nginx.lua
+++ b/src/nginx.lua
@@ -1,9 +1,13 @@
 -- package nginx: An nginx auth handler
 
 local SERVICE_PROXY_PATH = "/sub/service"
+local CLIENT_HEADER = "Fastly-Client-IP"
+local FORWARDED_FOR_HEADER = "X-Forwarded-For"
 
 local nginx = {
   SERVICE_PROXY_PATH = SERVICE_PROXY_PATH,
+  CLIENT_HEADER = CLIENT_HEADER,
+  FORWARDED_FOR_HEADER = FORWARDED_FOR_HEADER,
 }
 
 local auth = require "auth"
@@ -53,7 +57,7 @@ function nginx.authenticate(app, headers)
   return nil
 end
 
-function nginx.service_proxy(ngx, user_id)
+function nginx.service_proxy(ngx, user_id, headers)
   -- the X-Wikia-UserId header should either be set by a valid
   -- user id or cleared
   if user_id then
@@ -65,6 +69,8 @@ function nginx.service_proxy(ngx, user_id)
   -- clear the cookie; it should not be sent to the backend
   ngx.req.set_header(cookie.COOKIE_HEADER, "")
   ngx.req.set_header(auth.ACCESS_TOKEN_HEADER, "")
+
+  ngx.req.set_header(FORWARDED_FOR_HEADER, headers[CLIENT_HEADER])
 
   return ngx.exec("@service")
 end

--- a/src/nginx.lua
+++ b/src/nginx.lua
@@ -70,7 +70,9 @@ function nginx.service_proxy(ngx, user_id, headers)
   ngx.req.set_header(cookie.COOKIE_HEADER, "")
   ngx.req.set_header(auth.ACCESS_TOKEN_HEADER, "")
 
-  ngx.req.set_header(FORWARDED_FOR_HEADER, headers[CLIENT_HEADER])
+  if headers and headers[CLIENT_HEADER] then
+    ngx.req.set_header(FORWARDED_FOR_HEADER, headers[CLIENT_HEADER])
+  end
 
   return ngx.exec("@service")
 end

--- a/src/nginx/router.lua
+++ b/src/nginx/router.lua
@@ -10,7 +10,7 @@ function router.route()
 
   local headers = ngx.req.get_headers(100)
   local user_id = nginx.authenticate(app, headers)
-  return nginx.service_proxy(ngx, user_id)
+  return nginx.service_proxy(ngx, user_id, headers)
 end
 
 

--- a/t/TestHelper.pm
+++ b/t/TestHelper.pm
@@ -1,0 +1,34 @@
+package TestHelper;
+use strict;
+use Exporter;
+use File::Basename;
+
+our @ISA= qw( Exporter );
+
+# these are exported by default.
+our @EXPORT = qw( create_configured_locations create_http_config );
+
+sub create_configured_locations {
+    my ($filename) = @_;
+    mkdir(dirname($filename));
+    open(my $configured_locations, '>', $filename) || die "Couldn't open filename $filename!";
+    print $configured_locations qq{
+      local url_routes = {}
+      url_routes['test'] = "test"
+      return url_routes
+    };
+    close $configured_locations;
+}
+
+sub create_http_config {
+    my ($pwd) = @_;
+    return qq{
+  lua_package_path '${pwd}/t/lua/?.lua;${pwd}/src/?.lua;/usr/local/openresty/lualib/?.lua;;';
+  upstream test {
+    server wikia-api-gateway-backends.getsandbox.com;
+  }
+};
+
+}
+
+1;

--- a/t/TestHelper.pm
+++ b/t/TestHelper.pm
@@ -21,11 +21,11 @@ sub create_configured_locations {
 }
 
 sub create_http_config {
-    my ($pwd) = @_;
+    my ($pwd, $backend) = @_;
     return qq{
   lua_package_path '${pwd}/t/lua/?.lua;${pwd}/src/?.lua;/usr/local/openresty/lualib/?.lua;;';
   upstream test {
-    server wikia-api-gateway-backends.getsandbox.com;
+    server ${backend};
   }
 };
 

--- a/t/TestHelper.pm
+++ b/t/TestHelper.pm
@@ -6,7 +6,7 @@ use File::Basename;
 our @ISA= qw( Exporter );
 
 # these are exported by default.
-our @EXPORT = qw( create_configured_locations create_http_config );
+our @EXPORT = qw( create_configured_locations create_http_config create_lua_config );
 
 sub create_configured_locations {
     my ($filename) = @_;
@@ -18,6 +18,21 @@ sub create_configured_locations {
       return url_routes
     };
     close $configured_locations;
+}
+
+sub create_lua_config {
+    my ($filename) = @_;
+    if (-e $filename) {
+      return;
+    }
+    open(my $lua_config, '>', $filename) || die "Couldn't open filename $filename!";
+    print $lua_config qq{
+      local config = {}
+      config.HELIOS_URL = ""
+      config.SERVICE_LB_URL = ""
+      return config
+    };
+    close $lua_config;
 }
 
 sub create_http_config {

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,4 +1,4 @@
-# vim:set ft= ts=4 sw=4 et:
+# vim:set ft=perl ts=4 sw=4 et:
 use warnings;
 use strict;
 use File::Basename;
@@ -8,9 +8,10 @@ use lib dirname(abs_path($0));
 use TestHelper;
 
 our $pwd = cwd();
+our $APIGatewayTestMock = $ENV{"API_GATEWAY_TEST_MOCK"} || "wikia-api-gateway-backends.getsandbox.com";
 
 create_configured_locations($pwd . '/t/lua/configured_locations.lua');
-our $HttpConfig = create_http_config($pwd);
+our $HttpConfig = create_http_config($pwd, $APIGatewayTestMock);
 
 plan tests => repeat_each(1) * (2 * blocks());
 
@@ -66,9 +67,9 @@ world
       proxy_set_header Host $host;
       proxy_pass http://$upstream/$stripped_uri;
     }
---- more_headers
-Fastly-Client-IP: 10.10.10.10
-Host: wikia-api-gateway-backends.getsandbox.com
+--- more_headers eval
+"Fastly-Client-IP: 10.10.10.10
+Host: $::APIGatewayTestMock"
 --- request
     GET /test/x-forwarded-for
 --- response_body_like

--- a/t/basic.t
+++ b/t/basic.t
@@ -11,6 +11,7 @@ our $pwd = cwd();
 our $APIGatewayTestMock = $ENV{"API_GATEWAY_TEST_MOCK"} || "wikia-api-gateway-backends.getsandbox.com";
 
 create_configured_locations($pwd . '/t/lua/configured_locations.lua');
+create_lua_config($pwd . '/src/config.lua');
 our $HttpConfig = create_http_config($pwd, $APIGatewayTestMock);
 
 plan tests => repeat_each(1) * (2 * blocks());

--- a/t/sandbox.t
+++ b/t/sandbox.t
@@ -67,7 +67,6 @@ world
       proxy_pass http://$upstream/$stripped_uri;
     }
 --- more_headers
-X-Wikia-UserId: 1234
 Fastly-Client-IP: 10.10.10.10
 Host: wikia-api-gateway-backends.getsandbox.com
 --- request

--- a/t/sandbox.t
+++ b/t/sandbox.t
@@ -1,67 +1,18 @@
 # vim:set ft= ts=4 sw=4 et:
+use warnings;
+use strict;
 use File::Basename;
-use HTTP::Daemon;
-use HTTP::Status;
 use Test::Nginx::Socket;
-use IO::Socket::Timeout;
-use Parallel::ForkManager;
-use HTTP::Response;
-use Cwd qw(cwd);
-
-sub response {
-    my ($code, $content) = @_;
-    my $resp = HTTP::Response->new();
-    $resp->code($code);
-    $resp->content($content);
-    return $resp;
-}
-
-my $pm = new Parallel::ForkManager(1);
-my $httpd = HTTP::Daemon->new( Timeout => 2 ) || die;
-my $pid = $pm->start;
-if ($pid == 0) {
-    if (my $c = $httpd->accept) {
-      while (my $r = $c->get_request) {
-          if ($r->method eq 'GET' and $r->uri->path =~ "^/x-forwarded-for") {
-              $c->send_response(response(200, $r->header('X-Forwarded-For') . "\n"));
-          } else {
-              $c->send_error(RC_FORBIDDEN)
-          }
-      }
-      $c->close;
-      undef($c);
-  }
-
-  $pm->finish;
-}
-
-END {
-    $pm->wait_all_children;
-}
-
-repeat_each(1);
-plan tests => repeat_each() * (2 * blocks());
+use Cwd qw(cwd abs_path);
+use lib dirname(abs_path($0));
+use TestHelper;
 
 our $pwd = cwd();
-my $port = $httpd->sockport;
 
-my $filename = $pwd . '/t/lua/configured_locations.lua';
-mkdir(dirname($filename));
-open(my $configured_locations, '>', $filename) || die "Couldn't open filename $filename!";
-print $configured_locations qq{
-  local url_routes = {}
-  url_routes['test'] = "test"
-  return url_routes
-};
-close $configured_locations;
+create_configured_locations($pwd . '/t/lua/configured_locations.lua');
+our $HttpConfig = create_http_config($pwd);
 
-our $HttpConfig = qq{
-  lua_package_path '${pwd}/t/lua/?.lua;${pwd}/src/?.lua;/usr/local/openresty/lualib/?.lua;;';
-  upstream test {
-    server 127.0.0.1:${port};
-  }
-};
-
+plan tests => repeat_each(1) * (2 * blocks());
 
 no_shuffle();
 run_tests();
@@ -86,12 +37,12 @@ world
 --- http_config eval: $::HttpConfig
 --- config
     location /test {
-    proxy_pass_request_headers off;
     content_by_lua '
       local router = require("nginx/router")
       return router.route()
       ';
     }
+
     location @service {
       set_by_lua $upstream '
         local upstream = require("upstream")
@@ -112,12 +63,15 @@ world
           return
         end';
 
+      proxy_set_header Host $host;
       proxy_pass http://$upstream/$stripped_uri;
     }
 --- more_headers
+X-Wikia-UserId: 1234
 Fastly-Client-IP: 10.10.10.10
+Host: wikia-api-gateway-backends.getsandbox.com
 --- request
     GET /test/x-forwarded-for
---- response_body
-10.10.10.10
+--- response_body_like
+.*"ip": "10.10.10.10".*
 --- error_code: 200

--- a/t/sandbox.t
+++ b/t/sandbox.t
@@ -1,0 +1,123 @@
+# vim:set ft= ts=4 sw=4 et:
+use File::Basename;
+use HTTP::Daemon;
+use HTTP::Status;
+use Test::Nginx::Socket;
+use IO::Socket::Timeout;
+use Parallel::ForkManager;
+use HTTP::Response;
+use Cwd qw(cwd);
+
+sub response {
+    my ($code, $content) = @_;
+    my $resp = HTTP::Response->new();
+    $resp->code($code);
+    $resp->content($content);
+    return $resp;
+}
+
+my $pm = new Parallel::ForkManager(1);
+my $httpd = HTTP::Daemon->new( Timeout => 2 ) || die;
+my $pid = $pm->start;
+if ($pid == 0) {
+    if (my $c = $httpd->accept) {
+      while (my $r = $c->get_request) {
+          if ($r->method eq 'GET' and $r->uri->path =~ "^/x-forwarded-for") {
+              $c->send_response(response(200, $r->header('X-Forwarded-For') . "\n"));
+          } else {
+              $c->send_error(RC_FORBIDDEN)
+          }
+      }
+      $c->close;
+      undef($c);
+  }
+
+  $pm->finish;
+}
+
+END {
+    $pm->wait_all_children;
+}
+
+repeat_each(1);
+plan tests => repeat_each() * (2 * blocks());
+
+our $pwd = cwd();
+my $port = $httpd->sockport;
+
+my $filename = $pwd . '/t/lua/configured_locations.lua';
+mkdir(dirname($filename));
+open(my $configured_locations, '>', $filename) || die "Couldn't open filename $filename!";
+print $configured_locations qq{
+  local url_routes = {}
+  url_routes['test'] = "test"
+  return url_routes
+};
+close $configured_locations;
+
+our $HttpConfig = qq{
+  lua_package_path '${pwd}/t/lua/?.lua;${pwd}/src/?.lua;/usr/local/openresty/lualib/?.lua;;';
+  upstream test {
+    server 127.0.0.1:${port};
+  }
+};
+
+
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: sanity
+--- http_config eval: $::HttpConfig
+--- config
+    location /echo {
+        echo_before_body hello;
+        echo world;
+    }
+--- request
+    GET /echo
+--- response_body
+hello
+world
+--- error_code: 200
+
+=== TEST 2: X-Forwarded-For
+--- http_config eval: $::HttpConfig
+--- config
+    location /test {
+    proxy_pass_request_headers off;
+    content_by_lua '
+      local router = require("nginx/router")
+      return router.route()
+      ';
+    }
+    location @service {
+      set_by_lua $upstream '
+        local upstream = require("upstream")
+        return upstream.find(ngx.var.request_uri);
+      ';
+
+      set_by_lua $stripped_uri '
+        local util = require("util")
+        local stripped_uri = util.get_rest_after_url_prefix(ngx.var.request_uri)
+        return util.strip_leading_slash(stripped_uri)
+      ';
+
+      access_by_lua '
+        if ngx.var.upstream == "__not_found" then
+          ngx.status = ngx.HTTP_NOT_FOUND
+          ngx.say("Invalid service resource")
+        else
+          return
+        end';
+
+      proxy_pass http://$upstream/$stripped_uri;
+    }
+--- more_headers
+Fastly-Client-IP: 10.10.10.10
+--- request
+    GET /test/x-forwarded-for
+--- response_body
+10.10.10.10
+--- error_code: 200


### PR DESCRIPTION
This PR adds:
- pass through support for the `Fastly-Client-IP` header as `X-Forwarded-For`
- add tests for the pass through using `Test::Nginx::Socket`

Adding the testing revealed the need to break out some of the nginx configuration into separate files. This will allow the request logic to be included in the production ready nginx config and the tests.

https://wikia-inc.atlassian.net/browse/SERVICES-373

TODO:
 * [ ] break out the logic that was copy-pasted to the test and put it into a separate file
 * [x] minor: integrate the `t` directory into the travis build

@jcellary @macbre @Wikia/services-team 