### PR TITLE
Use $remote_addr to set X-Forwarded-For

### DIFF
--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -2,6 +2,7 @@ server {
   listen 8100 default_server;
   server_name "" [::]:8100;
   resolver 127.0.0.1:8600;
+  proxy_set_header X-Forwarded-For $remote_addr;
   header_filter_by_lua_file "$api_gateway_root/src/nginx/scripts/add_cors_headers.lua";
 
   access_log /var/log/nginx/api-gateway.access.log log_format_with_perf;

--- a/spec/nginx_spec.lua
+++ b/spec/nginx_spec.lua
@@ -32,7 +32,7 @@ describe("nginx module tests", function()
     it("will set the user id header when supplied", function()
       local nginx = require "nginx"
       local user_id = 1234;
-      local ret = nginx.service_proxy(ngx, user_id, {})
+      local ret = nginx.service_proxy(ngx, user_id)
 
       assert.stub(ngx.exec).was.called_with("@service")
 
@@ -43,7 +43,7 @@ describe("nginx module tests", function()
     it("will clear the user id header when the user id is not supplied", function()
       local nginx = require "nginx"
       local user_id = nil;
-      local ret = nginx.service_proxy(ngx, user_id, {})
+      local ret = nginx.service_proxy(ngx, user_id)
 
       assert.stub(ngx.exec).was.called_with("@service")
 

--- a/src/nginx.lua
+++ b/src/nginx.lua
@@ -1,13 +1,9 @@
 -- package nginx: An nginx auth handler
 
 local SERVICE_PROXY_PATH = "/sub/service"
-local CLIENT_HEADER = "Fastly-Client-IP"
-local FORWARDED_FOR_HEADER = "X-Forwarded-For"
 
 local nginx = {
   SERVICE_PROXY_PATH = SERVICE_PROXY_PATH,
-  CLIENT_HEADER = CLIENT_HEADER,
-  FORWARDED_FOR_HEADER = FORWARDED_FOR_HEADER,
 }
 
 local auth = require "auth"
@@ -57,7 +53,7 @@ function nginx.authenticate(app, headers)
   return nil
 end
 
-function nginx.service_proxy(ngx, user_id, headers)
+function nginx.service_proxy(ngx, user_id)
   -- the X-Wikia-UserId header should either be set by a valid
   -- user id or cleared
   if user_id then
@@ -69,10 +65,6 @@ function nginx.service_proxy(ngx, user_id, headers)
   -- clear the cookie; it should not be sent to the backend
   ngx.req.set_header(cookie.COOKIE_HEADER, "")
   ngx.req.set_header(auth.ACCESS_TOKEN_HEADER, "")
-
-  if headers and headers[CLIENT_HEADER] then
-    ngx.req.set_header(FORWARDED_FOR_HEADER, headers[CLIENT_HEADER])
-  end
 
   return ngx.exec("@service")
 end


### PR DESCRIPTION
We are now using the [`Fastly-Client-IP` as the "trusted" source for the client IP](https://github.com/Wikia/chef-repo/pull/7720). This means than in nginx the `$remote_addr` value should now be the "real" client and not a fastly or Wikia POP.

This PR reverts the manual setting of the `X-Forwarded-For` and sets this value using `$remote_addr`.

https://wikia-inc.atlassian.net/browse/SERVICES-373

@Wikia/services-team 