### PR TITLE
Use "auth" upstream when checking token info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ t/lua
 t/servroot
 tmp/
 .R*
+*.ipr
+*.iws
+*.iml

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ nginx config file in `nginx/conf/nginx.conf` should be enough to test.
 To start:
 
 ```
-./scripts/nginx-start
+./scripts/start-nginx
 ```
 
 You can test the basic functionality with:
@@ -159,7 +159,7 @@ dt push -a api-gateway -e prod
  dependencies for travis.
 
  If you are working on OS X consider using [openresty](http://openresty.org) for
- nginx. It comes configured to work with the api-gateway.
+ nginx. It comes configured to work with the api-gateway. See `scripts/install-openresty.sh`
 
  If you need to add additional nginx modules to openresty you might find it
  helpful to install openresty with homebrew. If you go this route you can add

--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -54,31 +54,14 @@ server {
   }
 
   location /token {
-    content_by_lua '
-      local http = require "resty.http"
-      local config = require "config"
+    set_by_lua $token_info_url '
+      local config = require("config")
+      local upstream = require("upstream")
+      local auth_service = upstream.find(config.AUTH_UPSTREAM_NAME)
+      return string.format("http://%s/info?code=%s", auth_service, ngx.var.arg_code)
+    ';
 
-      local request_headers = ngx.req.get_headers(100)
-
-      -- creating the http object in a module appears to be problematic
-      -- (see http://wiki.nginx.org/HttpLuaModule#Data_Sharing_within_an_Nginx_Worker)
-      local httpc = http.new()
-      httpc:set_timeout(5000)
-      local url = string.format("%s/info?code=%s", config.HELIOS_URL, ngx.var.arg_code)
-      local res, err = httpc:request_uri(url, {
-             method = "GET",
-             headers = request_headers,
-      })
-
-      if err then
-        ngx.log(ngx.ERR, "request error: " .. err)
-      end
-
-      if res then
-        ngx.say(res.body)
-      else
-        ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
-      end';
+    proxy_pass $token_info_url;
   }
 
   location @service {

--- a/scripts/install-openresty.sh
+++ b/scripts/install-openresty.sh
@@ -16,7 +16,11 @@ wget $DOWNLOAD_BASE/$PACKAGE
 tar zxvf $PACKAGE
 
 cd ngx_openresty-${VERSION}
-./configure --prefix=$HOME/local
+./configure \
+		--prefix=$HOME/local \
+		--with-cc-opt="-I/usr/local/opt/openssl/include/ -I/usr/local/opt/pcre/include/" \
+		--with-ld-opt="-L/usr/local/opt/openssl/lib/ -L/usr/local/opt/pcre/lib/" \
+		-j8
 make
 make install
 

--- a/src/nginx.lua
+++ b/src/nginx.lua
@@ -13,7 +13,6 @@ local util = require "util"
 local http = require "resty.http"
 
 function nginx.init(config)
-  config.HELIOS_URL = util.strip_trailing_slash(config.HELIOS_URL)
   config.SERVICE_LB_URL = util.strip_trailing_slash(config.SERVICE_LB_URL)
 
   local helios = helios:new(ngx)

--- a/t/TestHelper.pm
+++ b/t/TestHelper.pm
@@ -28,7 +28,6 @@ sub create_lua_config {
     open(my $lua_config, '>', $filename) || die "Couldn't open filename $filename!";
     print $lua_config qq{
       local config = {}
-      config.HELIOS_URL = ""
       config.SERVICE_LB_URL = ""
       return config
     };

--- a/templates/src/config.lua
+++ b/templates/src/config.lua
@@ -2,7 +2,7 @@
 --
 local config = {
   SERVICE_LB_URL = "{{key "config/api-gateway/SERVICE_LB_URL"}}",
-  HELIOS_URL = "{{key "config/api-gateway/HELIOS_URL"}}",
+  AUTH_UPSTREAM_NAME = "{{key_or_default "config/api-gateway/AUTH_UPSTREAM_NAME" "auth"}},
   SERVICE_HTTP_TIMEOUT = 0.1,
 }
 


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-1147

Rather than relying on a hardcoded url for helios, have the API gateway use the same upstreams it has configured when checking against a token. By default, it will use the same upstream that the `auth` service has defined. This will allow us to have `unavailable` serve requests in Reston using the same configuration we're already using (API gateway routing).