### PR TITLE
Change to key instead of key_or_default

### DIFF
--- a/templates/src/config.lua
+++ b/templates/src/config.lua
@@ -2,7 +2,7 @@
 --
 local config = {
   SERVICE_LB_URL = "{{key "config/api-gateway/SERVICE_LB_URL"}}",
-  AUTH_UPSTREAM_NAME = "{{key_or_default "config/api-gateway/AUTH_UPSTREAM_NAME" "auth"}}",
+  AUTH_UPSTREAM_NAME = "{{key "config/api-gateway/AUTH_UPSTREAM_NAME"}}",
   SERVICE_HTTP_TIMEOUT = 0.1,
 }
 


### PR DESCRIPTION
As the subject says. It looks like `key_or_default` isn't available with our version of `consul-template`.

@nmonterroso 