### PR TITLE
accept x-wikia-accesstoken and x-proof-of-work in ajax requests

### DIFF
--- a/src/cors.lua
+++ b/src/cors.lua
@@ -13,7 +13,7 @@ local cors = {
   allow_methods_header = "Access-Control-Allow-Methods",
   allow_credentials_header = "Access-Control-Allow-Credentials",
 
-  allow_headers_default_value = "Content-Type, Accept",
+  allow_headers_default_value = "Content-Type, Accept, X-Wikia-AccessToken, X-Proof-Of-Work",
   allow_methods_default_value = "POST,GET,OPTIONS,PUT,DELETE",
   allow_credentials_default_value = "true",
 


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-1238

Adding `X-Wikia-AccessToken` and `X-Proof-Of-Work` to accepted headers when checking `Access-Control-*` headers at the api gateway.