### PR TITLE
Make the /token resource internal-only

### DIFF
--- a/nginx/production/api-gateway.conf
+++ b/nginx/production/api-gateway.conf
@@ -54,6 +54,7 @@ server {
   }
 
   location /token {
+    internal;
     set_by_lua $token_info_url '
       local config = require("config")
       local upstream = require("upstream")


### PR DESCRIPTION
The `/token` resource should not be exposed to the outside. We can make this internal only by adding the `internal` directive. All external requests will then get a 404.

I manually confirmed that this works as expected. The internal request still work and the `X-Wikia-UserId` header is added as expected.

https://wikia-inc.atlassian.net/browse/SERVICES-1064

@Wikia/services-team 