### PR TITLE
Don't proxy the X-Wikia-Schwartz token

### DIFF
--- a/src/request_headers.lua
+++ b/src/request_headers.lua
@@ -6,6 +6,7 @@ local request = {
     USER_ID = "X-User-Id",
     ACCESS_TOKEN = "X-Wikia-AccessToken",
     FASTLY_CLIENT_IP = 'Fastly-Client-IP',
+    SCHWARTZ_TOKEN = 'X-Wikia-Schwartz',
 }
 
 function request.sanitize(ngx)
@@ -14,6 +15,7 @@ function request.sanitize(ngx)
     ngx.req.clear_header(request.REQUEST_ID)
     ngx.req.clear_header(request.USER_ID)
     ngx.req.clear_header(request.WIKIA_USER_ID)
+    ngx.req.clear_header(request.SCHWARTZ_TOKEN)
 end
 
 function request.set_headers(ngx)    


### PR DESCRIPTION
The Social team would like to start using the schwartz token as a header in order to validate an internal request. As part of that, we'd like to make sure that header can't be set from outside the gateway. This PR adds a `X-Wikia-Schwartz` header to the list of headers which are filtered out by the gateway.

cc @Wikia/services-team 